### PR TITLE
new feature: accessibility warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.act
+*.aux
+*.aws
+*.dvi
+*.ex
+*.idx
+*.log
+*.out
+*.thm
+*.toc
+*.synctex.gz

--- a/example.tex
+++ b/example.tex
@@ -6,6 +6,7 @@
 % reduceda4 = change paper size to reduced a4
 % nocomments = remove author and editor comments from output
 % standalone = produce standalone document (e.g. add copyright to first page)
+% a-w = accessibility warnings: highlight accessibility warnings
 
 \usepackage[nopar]{lipsum}%just for this example
 \usepackage{outikz}% the ouunit.sty is compatible with the OU figure styles
@@ -694,5 +695,5 @@ If a box is split across at least three pages then \verb"\newpage" in the middle
 
 \printexercisesolutions
 \printactivitysolutions
-\printindex
+\IfFileExists{\jobname.ind}{\printindex}{}
 \end{document}

--- a/ouunit.cls
+++ b/ouunit.cls
@@ -25,12 +25,17 @@
 \newif\if@standalone
 \@standalonefalse
 
+%switch to indicate if accessibility warnings active
+\newif\if@ouunit@accessibility@warnings
+\@ouunit@accessibility@warningsfalse
+
 \DeclareOption{final}{\draftfalse}
 \DeclareOption{reduceda4}{\@reducedtrue}
 \DeclareOption{solutionsatend}{\@tendtrue}
 \DeclareOption{twocolumnsolutions}{\@twocolsoltrue}
 \DeclareOption{nocomments}{\@nocommentstrue}
 \DeclareOption{standalone}{\@standalonetrue}
+\DeclareOption{a-w}{\@ouunit@accessibility@warningstrue}
 
 %\ExecuteOptions{}
 
@@ -148,7 +153,8 @@
 
 \DeclareRobustCommand{\itemid}[1]{}
 
-\DeclareRobustCommand{\uniqueID}[1]{}
+\global\let\@uniqueID\@empty
+\DeclareRobustCommand{\uniqueID}[1]{\DeclareRobustCommand\@uniqueID{#1}}
 
 \global\let\@author\@empty
 
@@ -792,5 +798,69 @@
 \DeclareRobustCommand*{\editorcomment}[1]{{\color{red!50!black}#1}}
 \fi
 
+%
+% accessibility warnings
+%
+\newcommand{\ouunitPrintAW}{}
+\newif\if@ouunit@accessibility@warnings@printed
+\@ouunit@accessibility@warnings@printedfalse
+
+\if@ouunit@accessibility@warnings%
+ \typeout{ouunit: accessibility warnings switch active}
+ \renewcommand{\ouunitPrintAW}{%
+  \@ouunit@accessibility@warnings@printedtrue%
+  \subsection*{Accessibility warnings summary}\@starttoc{aws}}
+ %
+ % command to output accessibility warning message
+ %
+ \newcommand{\ouunit@accessibility@warning@message}[2]{%
+  %
+  % \ouunit@accessibility@warning@message{<warning NUMBER>}{<warning MESSAGE>}
+  %
+  \marginnote{\color{red}\fbox{\fbox{\parbox{5cm}{\small\emph{AW#1: #2}}}}}%
+  \addcontentsline{aws}{subsubsection}{AW#1: #2}%
+  \typeout{ouunit: accessibility warning, AW#1: #2}
+ }
+ %
+ % AW1: list levels need to be <=2 for the VLE
+ %
+ \def\ou@unit@enum@plus@item@depth{\numexpr\@enumdepth+\@itemdepth\relax}%
+ \AtBeginEnvironment{enumerate}{%
+  \ifnum\ou@unit@enum@plus@item@depth>1%
+   \ouunit@accessibility@warning@message{1}{list depth (enumerate) more than 2}%
+  \fi
+ }
+ \AtBeginEnvironment{itemize}{%
+  \ifnum\ou@unit@enum@plus@item@depth>1%
+   \ouunit@accessibility@warning@message{1}{list depth (itemize) more than 2}%
+  \fi
+ }
+ %
+ % AW3: tabular in math environment
+ %
+ \BeforeBeginEnvironment{tabular}{%
+  \ifmmode%
+   \ouunit@accessibility@warning@message{3}{tabular in math mode}%
+  \fi
+ }
+\fi
+
+\AtEndDocument{%
+ \if@ouunit@accessibility@warnings%
+  %
+  % AW2: unique ID not specified
+  %
+  \ifx\@uniqueID\@empty%
+   \ouunit@accessibility@warning@message{2}{unique ID not specified}%
+  \fi
+  %
+  % check if \ouunitPrintAW has been called, and if not, then output summary
+  %
+  \if@ouunit@accessibility@warnings@printed\relax%
+  \else
+   \ouunitPrintAW%
+  \fi
+ \fi
+}%
 
 \endinput


### PR DESCRIPTION
Hi Robert,
Thanks for all of your work on `ouunit`. 

I have this contribution of `accessibility warnings` in this pull request for your review.  

I've put details and a demonstration below. I'd welcome any feedback and questions that you have.
Best
Chris

------------------------

what is this pull request about? why is it helpful/necessary?
-
This work is motivated by accessibility. I am hopeful that, by having an `accessibility warnings` option, some authors may enhance or change their typesetting habits.

does this change any existing behaviour?
-
No, this implements a new, _optional_ feature.

what does this add?
-

It adds a new option `a-w` (short for *accessibility warnings*) for `ouunit.cls` which can be specified as
```tex
\documentclass[a-w]{ouunit}
```

When the `a-w` option is active, then `\jobname.aws` will be created, which will contain `accessibility warnings`; these are outputted to `\jobname.pdf`, and to the log file, `\jobname.log`.

how do I test this?
-
If you compile the following minimal example
```tex
\documentclass[a-w]{ouunit}   %<----- NOTE, new option loaded
\begin{document}
an ouunit document
\end{document}
```
then you should receive the following pdf (two compilations necessary):

![image](https://github.com/RobertHasson/ouunit/assets/2224480/2228f054-c05a-4130-ab90-73888672f03e)

This is _one_ of the accessibility warnings, AW2, that is looked for by `ouunit.cls`. 

You should also see the following line in `\jobname.log`
```
ouunit: accessibility warning, AW2: unique ID not specified
```

If you remove the `a-w` option, as in 
```tex
\documentclass{ouunit}
\begin{document}
an ouunit document
\end{document}
```
then the accessibility warnings are not printed. 

further demonstration
-
You can see `AW1` and `AW3` in action by compiling the following file

<details>
     <summary>accessibility warnings 1 demo</summary>
      
```tex
\documentclass[a-w]{ouunit}
%metadata
\modulecode{MATHS}
\moduletitle{Generic module}
\unitid{0}
\unittitle{Style test}
\draftno{D1}	
\author{Robert Hasson}
\begin{document}

\section*{Accessibility warnings: list demonstrations}
\begin{enumerate}
 \item Another item
       \begin{itemize}
        \item second level itemize
        \item second level itemize
       \end{itemize}
       \begin{enumerate}
        \item Sub sub
        \item Sub sub question that runs a long time until it goes over to a second
              line
              \begin{enumerate}
               \item third level list; not rendered VLE
               \item third level list; not rendered VLE
              \end{enumerate}
        \item Sub sub question that runs a long time until it goes over to a second
              line
              \begin{itemize}
               \item third level list; not rendered VLE
               \item third level list; not rendered VLE
              \end{itemize}
       \end{enumerate}
\end{enumerate}

itemize list test warning demonstration
\begin{itemize}
 \item first level
       \begin{enumerate}
        \item second level
        \item second level
       \end{enumerate}
       \begin{itemize}
        \item second level
              \begin{itemize}
               \item third level
               \item third level
              \end{itemize}
              \begin{enumerate}
               \item third level
               \item third level
               \item third level
                     \begin{enumerate}
                      \item fourth level
                      \item fourth level
                     \end{enumerate}
              \end{enumerate}
       \end{itemize}
\end{itemize}

\section*{Accessibility warnings: tabular demonstration}
Equations should not contain \texttt{tabular} environments.
\[
 \begin{tabular}{cc}
  1 & 2 \\
  3 & 4
 \end{tabular}
\]
the following tabular is \emph{not} in math mode.

\begin{tabular}{cc}
 1 & 2 \\
 3 & 4
\end{tabular}

\end{document}

```
</details>

will these accessibility warnings ever be complete?
-
No, we would almost certainly add to these as we become aware of more issues. 

finally
-
I hope this is helpful. Do let me know if you have any questions or comments about any of this.